### PR TITLE
Dev1 test match history merge

### DIFF
--- a/backend/WebSocket/messageHandlers.js
+++ b/backend/WebSocket/messageHandlers.js
@@ -15,7 +15,7 @@ const {
 
 const {
 	updatePlayerGameStats,
-	
+	updateMatchHistory,
 } = require('@db/update.js');
 
 const {
@@ -148,10 +148,19 @@ function handleMessage(ws, data) {
 			console.log("game id:", gameId);
 			if (winner === 1){
 				updatePlayerGameStats(true, id1, player1.score)
-				 .catch(err => console.error('Failed to update player1 stats', err));
-//				if (data.type === "tournament"){
-//					updateTournamentStats(game.id, id1, player1.score, id2, player2.score);
-//				}
+					.catch(err => console.error('Failed to update player1 stats', err));
+				
+				updateMatchHistory(id1, 'win', player1.score, player1.type, id2, player2.score, player2.type)
+					.then (result => {
+						console.log("show me resluts from update match history", result);
+					})
+					.catch(err => console.error('failed to update match history', err));
+
+				updateMatchHistory(id2, 'loss', player2.score, player2.type, id1, player1.score, player1.type,)
+					.then (result => {
+						console.log("show me resluts from update match history", result);
+					})
+					.catch(err => console.error('failed to update match history', err));
 				//check login player updates
 				//if (typeof id2 === 'string' && !id2.includes('Guest')) {
 				//	updatePlayerGameStats(false, id2, player2.score)
@@ -165,6 +174,19 @@ function handleMessage(ws, data) {
 				//}
 				updatePlayerGameStats(false === 0, id1, player1.score)
 				 .catch(err => console.error('Failed to update player1 stats', err));
+				updateMatchHistory(id1, 'loss', player1.score, player1.type, id2, player2.score, player2.type)
+					.then (result => {
+						console.log("show me resluts from update match history", result);
+					})
+					.catch(err => console.error('failed to update match history', err));
+
+				updateMatchHistory(id2, 'win', player2.score, player2.type, id1, player1.score, player1.type)
+					.then (result => {
+						console.log("show me resluts from update match history", result);
+					})
+					.catch(err => console.error('failed to update match history', err));
+
+
 			}
 			if (game.mode === "tournament"){
 					
@@ -181,7 +203,7 @@ function handleMessage(ws, data) {
 					})
 					.catch(err => console.error('failed to update tournamnet stats', err));
 			}
-
+			
 			break;
 		}
 		case 'init': {

--- a/backend/database/get.js
+++ b/backend/database/get.js
@@ -104,26 +104,29 @@ async function getFriendsForPlayer( userId ) {
 	});
 }
 // can we have a schema that checks if table empty first?
-async function getMatchHistory({ userId }) {
+async function getMatchHistory(userId) {
 	//console			.log('DB::Fetching match history for user ID:', userId);
-	const test = userId.id;
+//	const test = userId.id;
 	return new Promise((resolve, reject) => {
 		db.all(
 			` 	SELECT 
-				    matches.user_id AS matchID,
-				    matches.result AS result,
-				    matches.score AS score,
-				    matches.timestamp AS timestamp, 
+				    match_history.user_id AS matchID,
+				    match_history.result AS result,
+				    match_history.user_score AS score,
+				    match_history.match_date AS timestamp,
+					users.username AS opponentUsername,
+					users.id AS userTableID,
+					match_history.opponent_id AS opid,
 				    CASE 
-				        WHEN matches.opponent_type = 'human' THEN users.username
-				        WHEN matches.opponent_type = 'guest' THEN 'Guest'
-				        WHEN matches.opponent_type = 'AI' THEN 'AI Bot'
-				    END AS opponentName
-				FROM matches
-				LEFT JOIN users ON matches.opponent_id = users.id
-				WHERE matches.user_id = ?;
+				        WHEN match_history.opponent_type = 'login' THEN users.username
+				        WHEN match_history.opponent_type = 'guest' THEN 'Guest'
+				        WHEN match_history.opponent_type = 'ai' THEN 'AI Bot'
+				    END AS opponent
+				FROM match_history
+				LEFT JOIN users ON match_history.opponent_id = users.id
+				WHERE match_history.user_id = ?;
 			`
-			,[test],
+			,[userId],
 			(err, rows) => {
 				if (err) {
 					console.error('DB error fetching match history:', err);
@@ -133,7 +136,10 @@ async function getMatchHistory({ userId }) {
 					}	
 					reject({ error: 'DB error fetching match history' });
 				} else {
-					console.log(`Found ${rows.length} matches for user ID ${userId}`);
+					//console.log(`Found ${rows.length} matches for user ID ${userId}`);
+					//console.log("whats going on with username -- ${rows.opponentUsername}");
+					//console.log("and the users.id is ${rows.userTableId}");
+					//console.log("and as opid ${rows.opid}")
 					resolve(rows || []);
 				}
 			}

--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -23,9 +23,10 @@ CREATE tABLE IF NOT EXISTS match_history
 (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	user_id INTEGER NOT NULL,
-	opponent_id INTEGER NOT NULL,
+	opponent_id INTEGER,
 	user_score INTEGER NOT NULL,
 	opponent_score INTEGER NOT NULL,
+	opponent_type TEXT NOT NULL CHECK (opponent_type IN ('login', 'guest', 'ai')),
 	result TEXT NOT NULL CHECK (result IN ('win', 'loss')),
 	match_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/database/update.js
+++ b/backend/database/update.js
@@ -182,14 +182,76 @@ async function applyTournamentId(userId, tournamentId){
 	})
 }
 //
-//async function updateMatchHistory(userId, matchData) {
-//	flog.debug({ function: 'updateMatchHistory', userId: userId, matchData: matchData }, 'Updating match history for user');
+async function updateMatchHistory(userId, result, userScore, userType, opponentId, opponentScore, opponentType) {
+  return new Promise((resolve, reject) => {
+	// must first make sure thet type has valid id, user1 will always be logged in
+	if (userType !== 'login') {
+    	return resolve({ message: `No match history needed for ${userType}` });
+	}
+	console.log("what is the id before all the shifty buisness", opponentId);
+	const numericOpponentId = opponentType === 'login' ? opponentId : null;
+	console.log("checking update match history that opponent id makes sense", numericOpponentId);
+	db.serialize(() => {
+      // Check how many matches the user has we rae capped at 10 at this moment
+      db.get(
+        'SELECT COUNT(*) AS count FROM match_history WHERE user_id = ?',
+        [userId],
+        (err, row) => {
+        	if (err) return reject({ error: 'Failed to count match history', details: err });
+			// Create a call back delete function in here as we wont use it anywhere else
+          const maybeDeleteOldest = (cb) => {
+            if (row.count >= 10) {
+              db.run(
+                'DELETE FROM match_history WHERE id = (SELECT id FROM match_history WHERE user_id = ? ORDER BY match_date ASC LIMIT 1)',
+                [userId],
+                cb
+              );
+            } else {
+              cb();
+            }
+          };
+
+          maybeDeleteOldest(() => {
+            //  Insert new match after if delete
+            db.run(
+              `INSERT INTO match_history 
+              (user_id, opponent_id, user_score, opponent_score, result, opponent_type, match_date) 
+              VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+              [userId, numericOpponentId, userScore, opponentScore, result, opponentType],
+              function (err) {
+                if (err) {
+                  reject({ error: 'Failed to insert match history', details: err });
+                } else {
+                  resolve({ 
+                    matchId: this.lastID,
+                    userId,
+                    opponentId,
+                    result,
+                    score: userScore,
+                    opponentScore,
+                    //timestamp: new Date().toISOString()
+					//this.chnages later
+                  });
+                }
+              }
+            );
+          });
+        }
+      );
+    });
+  });
+}
+
+//async function updateMatchHistory(userId, result, score, opponentId) {
+//	flog.debug({ function: 'updateMatchHistory', userId: userId }, 'Updating match history for user');
 //
 //	return new Promise((resolve, reject) => {
-//		// Assuming match_history is stored as a JSON string in the database
+//		db.get('FROM users WHERE id = ?',
+//		[]	
+//		)
 //		db.run(
-//			'UPDATE users SET match_history = ? WHERE id = ?',
-//			[JSON.stringify(matchData), userId],
+//			'INSERT INTO match_history = ? WHERE id = ?',
+//			[, userId],
 //			function (err) {
 //				if (err) {
 //					reject({ error: 'Failed to update match history', details: err});
@@ -211,5 +273,5 @@ module.exports = { updateUserScore,
 	update2fa,
 	updatePlayerGameStats,
 	applyTournamentId,
-//	updateMatchHistory
+	updateMatchHistory
 };

--- a/backend/routes/game.js
+++ b/backend/routes/game.js
@@ -191,7 +191,8 @@ async function joinGame(fastify, options) {
 				console.log('justi usgage', verifyUser);
 				let userId;
 				if (type === "login") {
-					userId = miniLogin(username, password);
+					const idObj = await miniLogin(username, password);
+					userId = idObj.id;
 
 					// if fails tell user can not register here
 				}

--- a/backend/routes/profile/profile.js
+++ b/backend/routes/profile/profile.js
@@ -65,7 +65,7 @@ async function getUser(fastify, options) {
 			//flog.warn({function: "getProfile", totalGames: profile.total_games}, "can we see total matches updated and recived==============================");
 			const friends = await DBget.getFriendsForPlayer(userId.id);
 	//		flog.info({function: 'getUser', friends}, 'checking friend object');
-			const matchHistory = await DBget.getMatchHistory({userId});
+			const matchHistory = await DBget.getMatchHistory(userId.id);
 
 			//const tid = await DBget.getActiveTournamentId(userId);
 			//const { password, ...safeUser } = profile;


### PR DESCRIPTION
#### Preview
This section focuses exclusively on match history. The profile API call returns match history data to the frontend, and the output reflects the following:

<details>
<summary><strong>Test Summary</strong></summary>

- Playing a game against a guest updates the current user's match history with the guest as the opponent.
- Playing a game against AI updates the current user's match history with the AI as the opponent.
- Playing a game against a logged-in second player updates match history for both users.
- Tournament games correctly update match history for both participants.
- Navigated across various pages, including refreshing, logging in and out, to verify that match history updates consistently across different user profiles.

</details>

The system currently limits match history to 10 entries per user, though this limit is easily configurable.

#### Known Issues

- Game statistics for the second logged-in player are not reflected in their user profile, although their match history is correctly updated.