### PR TITLE
Fixed error message for 2FA

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -217,7 +217,7 @@ const HomePage: React.FC = () => {
 			setTempAuthToken(null);
 
 		} catch (err: any) {
-			setFormError(err?.message || t("home.error.generic"));
+			alert(err?.message || t("home.error.generic"));
 		}
 	};
 


### PR DESCRIPTION
Fixed error message for 2FA uses alert like all error messages should in 2FA instead setFormError messages that are used in other errors in login/register